### PR TITLE
Use scl_source rather than internal X_SCLS

### DIFF
--- a/enable.sh
+++ b/enable.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-source /opt/rh/{{collection}}/enable
-export X_SCLS="`scl enable {{collection}} 'echo $X_SCLS'`"
+source /usr/bin/scl_source {{collection}}


### PR DESCRIPTION
scl-utils include scl_source that can and imho should be used for enabling collections in the current directory. It feels more correct than touching private variable X_SCLS.
